### PR TITLE
fix: VL-3209 -  Android app is crashed after tapping on the drop-down fields

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@velocitycareerlabs/react-native-jsonschema-web-form",
-  "version": "0.3.84",
+  "version": "0.3.85",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@velocitycareerlabs/react-native-jsonschema-web-form",
-      "version": "0.3.84",
+      "version": "0.3.85",
       "license": "MIT",
       "dependencies": {
         "deprecated-react-native-prop-types": "^2.3.0",
@@ -15,7 +15,7 @@
         "prop-types": "^15.6.2",
         "react-native-image-picker": "3.8.1",
         "react-native-modal": "^11.5.6",
-        "react-native-modal-dropdown": "git+https://github.com/siemiatj/react-native-modal-dropdown.git",
+        "react-native-modal-dropdown": "git+https://github.com/siemiatj/react-native-modal-dropdown.git#9ebaf21a51405dd240534703df8df3739f51237a",
         "react-native-picker": "github:beefe/react-native-picker#6fa89e921c93279e8c0ef6dc871bd13aeddad158",
         "react-native-raw-bottom-sheet": "^2.2.0",
         "underscore.string": "^3.3.5"
@@ -9805,8 +9805,8 @@
     },
     "node_modules/react-native-modal-dropdown": {
       "version": "1.0.2",
-      "resolved": "git+ssh://git@github.com/siemiatj/react-native-modal-dropdown.git#74b5e4cc8c6591b839992ba9dd22e074dc64b74d",
-      "integrity": "sha512-x0+8bNrRF49XKa6RCPbzw9w5DwoJlZr3w1XxRgkFYNucayXvV3mfgv4UJY9KrOaExV/UWh3SM+t+9PQxLy6I/A==",
+      "resolved": "git+ssh://git@github.com/siemiatj/react-native-modal-dropdown.git#9ebaf21a51405dd240534703df8df3739f51237a",
+      "integrity": "sha512-m/naKHFJjDmj5kTJEh9WSw/AXQFxH5EB3TR6bvPbY+ERWOIvf2bcfTTW+ZGlJEtCIRaPJeiwGtqZ6oHMJOZi4g==",
       "license": "MIT",
       "dependencies": {
         "prop-types": "^15.6.0"
@@ -19165,9 +19165,9 @@
       }
     },
     "react-native-modal-dropdown": {
-      "version": "git+ssh://git@github.com/siemiatj/react-native-modal-dropdown.git#74b5e4cc8c6591b839992ba9dd22e074dc64b74d",
-      "integrity": "sha512-x0+8bNrRF49XKa6RCPbzw9w5DwoJlZr3w1XxRgkFYNucayXvV3mfgv4UJY9KrOaExV/UWh3SM+t+9PQxLy6I/A==",
-      "from": "react-native-modal-dropdown@git+https://github.com/siemiatj/react-native-modal-dropdown.git",
+      "version": "git+ssh://git@github.com/siemiatj/react-native-modal-dropdown.git#9ebaf21a51405dd240534703df8df3739f51237a",
+      "integrity": "sha512-m/naKHFJjDmj5kTJEh9WSw/AXQFxH5EB3TR6bvPbY+ERWOIvf2bcfTTW+ZGlJEtCIRaPJeiwGtqZ6oHMJOZi4g==",
+      "from": "react-native-modal-dropdown@git+https://github.com/siemiatj/react-native-modal-dropdown.git#9ebaf21a51405dd240534703df8df3739f51237a",
       "requires": {
         "prop-types": "^15.6.0"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@velocitycareerlabs/react-native-jsonschema-web-form",
-  "version": "0.3.84",
+  "version": "0.3.85",
   "private": false,
   "main": "index.js",
   "scripts": {
@@ -49,7 +49,7 @@
     "prop-types": "^15.6.2",
     "react-native-image-picker": "3.8.1",
     "react-native-modal": "^11.5.6",
-    "react-native-modal-dropdown": "git+https://github.com/siemiatj/react-native-modal-dropdown.git",
+    "react-native-modal-dropdown": "git+https://github.com/siemiatj/react-native-modal-dropdown.git#9ebaf21a51405dd240534703df8df3739f51237a",
     "react-native-picker": "github:beefe/react-native-picker#6fa89e921c93279e8c0ef6dc871bd13aeddad158",
     "react-native-raw-bottom-sheet": "^2.2.0",
     "underscore.string": "^3.3.5"

--- a/src/widgets/SelectWidget.js
+++ b/src/widgets/SelectWidget.js
@@ -169,6 +169,7 @@ const SelectWidget = (props) => {
         dropdownTextStyle={[theme.input.regular.text, styles.item]}
         dropdownStyle={[styles.dropdown, { height: dropdownHeight > 200 ? 200 : dropdownHeight }]}
         options={labels}
+        dropdownListProps={{}}
         onSelect={onSelect}
         renderSeparator={() => <View />}
       >


### PR DESCRIPTION
the issue caused by [latest upgrade](https://github.com/siemiatj/react-native-modal-dropdown/commit/9ebaf21a51405dd240534703df8df3739f51237a) of dependency react-native-modal-dropdown and not specified  implicitly dependency commit in package.json.